### PR TITLE
Don't start a shell in the BeyondDebug terminal.

### DIFF
--- a/src/beyDbgSession.ts
+++ b/src/beyDbgSession.ts
@@ -99,7 +99,7 @@ export class BeyDbgSessionNormal extends DebugSession {
         return value.name==='BeyondDebug';
       });
       if(!tm){
-         tm=vscode.window.createTerminal({name: "BeyondDebug", shellPath: "/bin/cat", isTransient: true});
+         tm=vscode.window.createTerminal({ name: 'BeyondDebug', shellPath: '/bin/cat', isTransient: true });
       }
       tm.show(true);
       let pid=await tm.processId;

--- a/src/beyDbgSession.ts
+++ b/src/beyDbgSession.ts
@@ -99,7 +99,7 @@ export class BeyDbgSessionNormal extends DebugSession {
         return value.name==='BeyondDebug';
       });
       if(!tm){
-         tm=vscode.window.createTerminal('BeyondDebug');
+         tm=vscode.window.createTerminal({name: "BeyondDebug", shellPath: "/bin/cat", isTransient: true});
       }
       tm.show(true);
       let pid=await tm.processId;


### PR DESCRIPTION
Previously BeyondDebug would start a shell in its terminal, causing the shell
prompt to get mixed into the program output. Instead, run /bin/cat as the shell
so we don't get an additional output in the terminal. Also set the terminal to
be non-persistent so it goes away when vscode is restarted.
